### PR TITLE
Added deployment scripts for Azure websites

### DIFF
--- a/.deployment
+++ b/.deployment
@@ -1,0 +1,2 @@
+[config]
+command = deploy.cmd

--- a/Web/App/Pages/App.js
+++ b/Web/App/Pages/App.js
@@ -1,4 +1,4 @@
-﻿(function () {
+﻿;(function () {
     'use strict';
 
     //TODO: INJECT DEPENDENCIES
@@ -59,9 +59,8 @@
     //        } else {
     //            vm.toolbar = '';
     //        }
-            
-    //    });
-        
-    //}]);
-})()
 
+    //    });
+
+    //}]);
+})();

--- a/Web/App/Pages/Config.js
+++ b/Web/App/Pages/Config.js
@@ -1,4 +1,4 @@
-﻿(function () {
+﻿;(function () {
     'use strict';
 
     angular.module('esqtv.pages').config(function ($routeProvider, $locationProvider) {

--- a/Web/App/Pages/Config.js
+++ b/Web/App/Pages/Config.js
@@ -14,9 +14,23 @@
                 }
             })
             .when('/pages/create', {
-                templateUrl: '/App/Pages/Views/Create.html',
-                controller: 'PageCreateCntrl',
-                controllerAs: 'vm'
+                templateUrl: '/App/Pages/Views/Edit.html',
+                controller: 'PageEditCntrl',
+                controllerAs: 'vm',
+                resolve: {
+                    page: function ($route, PageService) {
+                        return {
+                            "id": "",
+                            "title": "",
+                            "permaLink": "",
+                            "publishDate": moment().format(),//2015-04-16T15:52:12.6951395
+                            "expirationDate": moment().format(),
+                            "modifiedDate": moment().format(),
+                            "createdDate": moment().format(),
+                            "contentParts": []
+                        }
+                    }
+                }
             })
             .when('/pages/edit/:id', {
                 templateUrl: '/App/Pages/Views/Edit.html', controller: 'PageEditCntrl', controllerAs: 'vm',

--- a/Web/App/Pages/Controllers/PageCreateCntrl.js
+++ b/Web/App/Pages/Controllers/PageCreateCntrl.js
@@ -1,4 +1,5 @@
 ﻿/// <reference path="../Views/Edit.html" />
+;(function () {
 'use strict';
 
 angular.module('esqtv.pages').controller("PageCreateCntrl", ['$scope', '$sce', '$http', '$q', '$mdDialog', '$routeParams', '$location', 'KeywordService', 'pageComponent', 'PageService', 'NotifierService', pageCreateCntrl]);
@@ -139,3 +140,5 @@ function pageCreateCntrl($scope, $sce, $http, $q, $mdDialog, $routeParams, $loca
         });
     }
 }
+
+})();

--- a/Web/App/Pages/Controllers/PageEditCntrl.js
+++ b/Web/App/Pages/Controllers/PageEditCntrl.js
@@ -3,11 +3,11 @@
 
 'use strict';
 
-angular.module('esqtv.pages').controller("PageEditCntrl", ['$scope', '$sce', '$http', '$q', '$mdDialog', '$routeParams', '$window', '$location', 'page', 'KeywordService', 'pageComponent', 'PageService', 'NotifierService', pageEditCntrl]);
+angular.module('esqtv.pages').controller("PageEditCntrl", ['$route', '$scope', '$sce', '$http', '$q', '$mdDialog', '$routeParams', '$window', '$location', 'page', 'KeywordService', 'pageComponent', 'PageService', 'NotifierService', pageEditCntrl]);
 
-function pageEditCntrl($scope, $sce, $http, $q, $mdDialog, $routeParams, $window, $location, page, KeywordService, pageComponent, PageService, NotifierService) {
+function pageEditCntrl($route, $scope, $sce, $http, $q, $mdDialog, $routeParams, $window, $location, page, KeywordService, pageComponent, PageService, NotifierService) {
     var vm = this;
-
+    vm.isEdit = ($window.location.href.indexOf('edit') > 0);
     // Page related items
     vm.page = page;
     vm.layout = 'layout-default';
@@ -119,12 +119,14 @@ function pageEditCntrl($scope, $sce, $http, $q, $mdDialog, $routeParams, $window
     }
 
     function publish() {
-        PageService.publish(vm.page.id).then(function (data) {
-            console.log(data);
-            NotifierService.notifySuccess('Record Published!');
-        }, function (err) {
-            console.log(err);
-        });
+        if (vm.isEdit) {
+            PageService.publish(vm.page.id).then(function (data) {
+                console.log(data);
+                NotifierService.notifySuccess('Record Published!');
+            }, function (err) {
+                console.log(err);
+            });
+        }
     }
 
     function save() {
@@ -136,13 +138,23 @@ function pageEditCntrl($scope, $sce, $http, $q, $mdDialog, $routeParams, $window
         });
 
         console.log(JSON.stringify(vm.page));
+        if (vm.isEdit) {
+            PageService.update(vm.page).then(function (result) {
+                NotifierService.notifySuccess('Record Saved!');
 
-        PageService.update(vm.page).then(function (result) {
-            NotifierService.notifySuccess('Record Saved!');
-
-        }, function (err) {
-            throw new Error(err.data.ResponseStatus.Message);
-        });
+            }, function (err) {
+                throw new Error(err.data.ResponseStatus.Message);
+            });
+        } else {
+            PageService.create(vm.page).then(function (result) {
+                var id = result.data.id;
+                NotifierService.notifySuccess('Record Created!');
+                $location.url('/pages/edit/' + id);
+            }, function (err) {
+                console.log(err);
+                throw new Error(err.data.ResponseStatus.Message);
+            });
+        }
     }
 
     function addComponent(componentType, $evt) {

--- a/Web/App/Pages/Controllers/PageEditCntrl.js
+++ b/Web/App/Pages/Controllers/PageEditCntrl.js
@@ -1,4 +1,6 @@
 ﻿/// <reference path="../Views/Edit.html" />
+;(function () {
+
 'use strict';
 
 angular.module('esqtv.pages').controller("PageEditCntrl", ['$scope', '$sce', '$http', '$q', '$mdDialog', '$routeParams', '$window', '$location', 'page', 'KeywordService', 'pageComponent', 'PageService', 'NotifierService', pageEditCntrl]);
@@ -162,3 +164,5 @@ function pageEditCntrl($scope, $sce, $http, $q, $mdDialog, $routeParams, $window
         });
     }
 }
+
+})();

--- a/Web/App/Pages/Controllers/PageIndexCntrl.js
+++ b/Web/App/Pages/Controllers/PageIndexCntrl.js
@@ -1,4 +1,6 @@
-﻿'use strict';
+﻿;(function () {
+
+'use strict';
 
 angular.module('esqtv.pages').controller("PageIndexCntrl", ['$scope', '$sce', '$http', '$q', '$routeParams', '$window', '$location', 'pages', pageIndexCntrl]);
 
@@ -41,3 +43,5 @@ function pageIndexCntrl($scope, $sce, $http, $q, $routeParams, $window, $locatio
         $location.path('/pages/edit/' + itm.id);
     });
 }
+
+})();

--- a/Web/App/Pages/Directives/Components.js
+++ b/Web/App/Pages/Directives/Components.js
@@ -1,4 +1,4 @@
-﻿(function () {
+﻿;(function () {
     'use strict';
     angular.module('esqtv.pages').directive('component', ['$compile', 'esqtvSettings', function ($compile, esqtvSettings) {
 

--- a/Web/App/Pages/Directives/ckEditor.js
+++ b/Web/App/Pages/Directives/ckEditor.js
@@ -1,4 +1,4 @@
-﻿(function () {
+﻿;(function () {
     'use strict';
     angular.module('esqtv.pages').directive('ckEditor', [function () {
         return {

--- a/Web/Inception.Web.csproj
+++ b/Web/Inception.Web.csproj
@@ -318,6 +318,9 @@
   <ItemGroup>
     <Content Include="Views\Home\Pages.cshtml" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include=".bowerrc" />
+  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>

--- a/Web/Web.Release.config
+++ b/Web/Web.Release.config
@@ -14,6 +14,9 @@
         xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
     </connectionStrings>
   -->
+  <appSettings>
+    <add xdt:Transform="Replace" xdt:Locator="Match(key)" key="WebsiteBase" value="http://esqtv-material.azurewebsites.net/" />
+  </appSettings>
   <system.web>
     <compilation xdt:Transform="RemoveAttributes(debug)" />
     <!--

--- a/Web/bower.json
+++ b/Web/bower.json
@@ -29,5 +29,8 @@
     "angular-ui-sortable": "~0.13.3",
     "ng-mfb": "~0.6.0",
     "ionicons": "~2.0.1"
+  },
+  "resolutions": {
+    "angular": "1.3.15"
   }
 }

--- a/Web/bower.json
+++ b/Web/bower.json
@@ -12,7 +12,7 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.3.15",
+    "angular": "#1.3.15",
     "bootstrap": "~3.3.4",
     "angular-route": "~1.3.15",
     "angularjs-toaster": "~0.4.13",

--- a/deploy.cmd
+++ b/deploy.cmd
@@ -1,0 +1,128 @@
+@if "%SCM_TRACE_LEVEL%" NEQ "4" @echo off
+
+:: ----------------------
+:: KUDU Deployment Script
+:: Version: 0.1.13
+:: ----------------------
+
+:: Prerequisites
+:: -------------
+
+:: Verify node.js installed
+where node 2>nul >nul
+IF %ERRORLEVEL% NEQ 0 (
+  echo Missing node.js executable, please install node.js, if already installed make sure it can be reached from current environment.
+  goto error
+)
+
+:: Setup
+:: -----
+
+setlocal enabledelayedexpansion
+
+SET ARTIFACTS=%~dp0%..\artifacts
+
+IF NOT DEFINED DEPLOYMENT_SOURCE (
+  SET DEPLOYMENT_SOURCE=%~dp0%.
+)
+
+IF NOT DEFINED DEPLOYMENT_TARGET (
+  SET DEPLOYMENT_TARGET=%ARTIFACTS%\wwwroot
+)
+
+IF NOT DEFINED NEXT_MANIFEST_PATH (
+  SET NEXT_MANIFEST_PATH=%ARTIFACTS%\manifest
+
+  IF NOT DEFINED PREVIOUS_MANIFEST_PATH (
+    SET PREVIOUS_MANIFEST_PATH=%ARTIFACTS%\manifest
+  )
+)
+
+IF NOT DEFINED KUDU_SYNC_CMD (
+  :: Install kudu sync
+  echo Installing Kudu Sync
+  call npm install kudusync -g --silent
+  IF !ERRORLEVEL! NEQ 0 goto error
+
+  :: Locally just running "kuduSync" would also work
+  SET KUDU_SYNC_CMD=%appdata%\npm\kuduSync.cmd
+)
+IF NOT DEFINED DEPLOYMENT_TEMP (
+  SET DEPLOYMENT_TEMP=%temp%\___deployTemp%random%
+  SET CLEAN_LOCAL_DEPLOYMENT_TEMP=true
+)
+
+IF DEFINED CLEAN_LOCAL_DEPLOYMENT_TEMP (
+  IF EXIST "%DEPLOYMENT_TEMP%" rd /s /q "%DEPLOYMENT_TEMP%"
+  mkdir "%DEPLOYMENT_TEMP%"
+)
+
+IF NOT DEFINED MSBUILD_PATH (
+  SET MSBUILD_PATH=%WINDIR%\Microsoft.NET\Framework\v4.0.30319\msbuild.exe
+)
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: Deployment
+:: ----------
+
+echo Handling .NET Web Application deployment.
+
+:: 1. Restore NuGet packages
+IF /I "Inception.sln" NEQ "" (
+  call :ExecuteCmd nuget restore "%DEPLOYMENT_SOURCE%\Inception.sln"
+  IF !ERRORLEVEL! NEQ 0 goto error
+)
+
+:: 2. Build to the temporary path
+IF /I "%IN_PLACE_DEPLOYMENT%" NEQ "1" (
+  call :ExecuteCmd "%MSBUILD_PATH%" "%DEPLOYMENT_SOURCE%\Web\Inception.Web.csproj" /nologo /verbosity:m /t:Build /t:pipelinePreDeployCopyAllFilesToOneFolder /p:_PackageTempDir="%DEPLOYMENT_TEMP%";AutoParameterizationWebConfigConnectionStrings=false;Configuration=Release /p:SolutionDir="%DEPLOYMENT_SOURCE%\.\\" %SCM_BUILD_ARGS%
+) ELSE (
+  call :ExecuteCmd "%MSBUILD_PATH%" "%DEPLOYMENT_SOURCE%\Web\Inception.Web.csproj" /nologo /verbosity:m /t:Build /p:AutoParameterizationWebConfigConnectionStrings=false;Configuration=Release /p:SolutionDir="%DEPLOYMENT_SOURCE%\.\\" %SCM_BUILD_ARGS%
+)
+
+IF !ERRORLEVEL! NEQ 0 goto error
+
+:: 3. KuduSync
+IF /I "%IN_PLACE_DEPLOYMENT%" NEQ "1" (
+  call :ExecuteCmd "%KUDU_SYNC_CMD%" -v 50 -f "%DEPLOYMENT_TEMP%" -t "%DEPLOYMENT_TARGET%" -n "%NEXT_MANIFEST_PATH%" -p "%PREVIOUS_MANIFEST_PATH%" -i ".git;.hg;.deployment;deploy.cmd"
+  IF !ERRORLEVEL! NEQ 0 goto error
+)
+
+:: 4. Bower Install
+if EXIST "%DEPLOYMENT_TARGET%\Web\bower.json" (
+    pushd "%DEPLOYMENT_TARGET%\Web"
+    call :ExecuteCmd bower install
+    IF !ERRORLEVEL! NEQ 0 goto error
+    popd
+)
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+:: Post deployment stub
+IF DEFINED POST_DEPLOYMENT_ACTION call "%POST_DEPLOYMENT_ACTION%"
+IF !ERRORLEVEL! NEQ 0 goto error
+
+goto end
+
+:: Execute command routine that will echo out when error
+:ExecuteCmd
+setlocal
+set _CMD_=%*
+call %_CMD_%
+if "%ERRORLEVEL%" NEQ "0" echo Failed exitCode=%ERRORLEVEL%, command=%_CMD_%
+exit /b %ERRORLEVEL%
+
+:error
+endlocal
+echo An error has occurred during web site deployment.
+call :exitSetErrorLevel
+call :exitFromFunction 2>nul
+
+:exitSetErrorLevel
+exit /b 1
+
+:exitFromFunction
+()
+
+:end
+endlocal
+echo Finished successfully.

--- a/deploy.cmd
+++ b/deploy.cmd
@@ -89,8 +89,8 @@ IF /I "%IN_PLACE_DEPLOYMENT%" NEQ "1" (
 )
 
 :: 4. Bower Install
-if EXIST "%DEPLOYMENT_TARGET%\Web\bower.json" (
-    pushd "%DEPLOYMENT_TARGET%\Web"
+if EXIST "%DEPLOYMENT_TARGET%\Wbower.json" (
+    pushd "%DEPLOYMENT_TARGET%"
     call :ExecuteCmd bower install
     IF !ERRORLEVEL! NEQ 0 goto error
     popd

--- a/deploy.cmd
+++ b/deploy.cmd
@@ -89,7 +89,7 @@ IF /I "%IN_PLACE_DEPLOYMENT%" NEQ "1" (
 )
 
 :: 4. Bower Install
-if EXIST "%DEPLOYMENT_TARGET%\Wbower.json" (
+if EXIST "%DEPLOYMENT_TARGET%\bower.json" (
     pushd "%DEPLOYMENT_TARGET%"
     call :ExecuteCmd bower install
     IF !ERRORLEVEL! NEQ 0 goto error


### PR DESCRIPTION
### Deployment
- Added deployment scripts used to automatically run when deploying to azure websites
- Included .bowerrc in .csproj so it can be deployed to the deployment target
- Specified angularjs to use version 1.3.15 in bower.json to silently resolve during unattended 'bower install' command in azure websites
- Added initial semicolon ';' to all scripts to ensure they terminate javascript lines when the files are concatenated
- Wrapped angular components in an Immediately Invoked Function Expression (IIFE) that were missing them.
### Page Create
- Changed the resolve to use the PageEditController. Will now resolve the page to an empty content page object.
- Added a check in PageEditCntrl.js to check if the $location is an edit screen or not. If it is, it sets a value vm.isEdit. This is used in the vm.save() and vm.publish() functions. If a user is trying to save in create mode, it sends a POST request, else it sends a PUT request. If a user tries to publish in create mode, it doesn't do anything.

TODO: Need to disable the publish button when in create mode.
TODO: Also need to implement a date/time picker for publish and expiry dates.
