### PR TITLE
UI Cleanup

### DIFF
--- a/Web/App/Common/App.js
+++ b/Web/App/Common/App.js
@@ -16,7 +16,7 @@
     ////template: '<div class="video-search-container"><h4>{{keywordId.keywords}}</h4><div class="row"><ul class="col-md-12"><li class="video-item col-md-3 col-lg-2 col-sm-3" data-ng-repeat="video in videosList"><div class="image-container"><img class="img-responsive" data-ng-src="{{thumbnailUrl(video.ThumbnailUrl)}}" alt="{{title(video.Name)}}" /></div><p>{{title(video.Name)}}</p></li></ul></div></div>',
     angular.module("template/esqtv/videos/related.html", []).run(["$templateCache", function ($templateCache) {
         $templateCache.put("template/esqtv/videos/related.html",
-        '<md-grid-list md-cols-sm="1" md-cols-md="2" md-cols-gt-md="6" md-row-height-gt-md="1:1" md-row-height="2:2" md-gutter="12px" md-gutter-gt-sm="8px">\n' + 
+        '<md-grid-list md-cols-sm="1" md-cols-md="2" md-cols-gt-md="4" md-row-height-gt-md="1:1" md-row-height="2:2" md-gutter="12px" md-gutter-gt-sm="8px">\n' + 
           '<md-grid-tile data-ng-repeat="video in videosList">\n' +
             '<img class="img-responsive" data-ng-src="{{thumbnailUrl(video.ThumbnailUrl)}}" alt="{{title(video.Name)}}" />\n' +
            '<md-grid-tile-footer>\n' +

--- a/Web/App/Common/Directives/Helpers.js
+++ b/Web/App/Common/Directives/Helpers.js
@@ -9,13 +9,13 @@
                 buttontext: "@",
                 labeltext: "@"
             },
-            template: '<md-list-item layout="row">'+
+            template: '<div layout="row" layout-align="start center">'+
                         '<md-input-container>'+
                             '<label>{{labeltext}}</label>' +
                             '<input type="text" data-ng-model="query" ent-enter action="search()" />' +
                         '</md-input-container>'+
-                        '<md-button ng-click="search()" class="btn btn-primary"><i class="glyphicon glyphicon-search">{{buttontext}}</md-button>' +
-                      '</md-list-item>'
+                        '<md-button ng-click="search()" class="btn btn-primary">{{buttontext}}</md-button>' +
+                      '</div>'
         };
     });
     

--- a/Web/App/Common/Directives/Videos.js
+++ b/Web/App/Common/Directives/Videos.js
@@ -3,7 +3,7 @@
     angular.module('esqtv.common').directive('videoSearch', ['esqtvSettings', function (esqtvSettings) {
         return {
             restrict: 'E',
-            controller: ['$scope', 'VideoService', function ($scope, VideoService) {
+            controller: ['$scope', 'VideoService', function ($scope, VideoService) {                
                 var vm = this;
                 vm.selectItem = selectItem;
                 vm.search = {
@@ -18,7 +18,7 @@
                     numPages: 10,
                     totalItems: 0,
                     currentPage: 1,
-                    itemsPerPage: 12,
+                    itemsPerPage: vm.itemsPerPage ? vm.itemsPerPage : 12,
                     onSelectPage: function () {
 
                         searchVideos();
@@ -51,7 +51,7 @@
                     $scope.$emit('esqtv:common:video:select', itm);
                 }
 
-                function searchVideos() {
+                function searchVideos() {                    
                     VideoService.search(vm.search, vm.paging)
                     .then(function (data) {
                         vm.search.results = data.Result;
@@ -63,7 +63,8 @@
             templateUrl: esqtvSettings.cms + '/App/Common/Views/VideoSearch.html',
             bindToController: true,
             scope: {
-                'selectedVideo': '='
+                'selectedVideo': '=',
+                'itemsPerPage': '@'
             }
         };
     }]);

--- a/Web/App/Pages/Controllers/PageIndexCntrl.js
+++ b/Web/App/Pages/Controllers/PageIndexCntrl.js
@@ -16,7 +16,7 @@ function pageIndexCntrl($scope, $sce, $http, $q, $routeParams, $window, $locatio
     };
 
     vm.paging = {
-        numPages: 10,
+        numPages: 5,
         totalItems: 0,
         currentPage: 1,
         itemsPerPage: 12,

--- a/Web/App/Pages/Views/Edit.html
+++ b/Web/App/Pages/Views/Edit.html
@@ -42,9 +42,9 @@
         </md-card>
     </md-content>
 </section>
-<nav mfb-menu position="br" effect="zoomin" label="Actions"
+<nav mfb-menu position="br" effect="slidein" label="Actions"
      active-icon="ion-android-arrow-up" resting-icon="ion-edit"
-     toggling-method="hover">
+     toggling-method="click">
     <button mfb-button icon="ion-plus" label="Add components" ng-click="vm.add()"></button>
     <button mfb-button icon="ion-grid" label="Reorder components" ng-click="vm.sort()"></button>
 </nav>

--- a/Web/App/Pages/Views/Index.html
+++ b/Web/App/Pages/Views/Index.html
@@ -1,13 +1,8 @@
 ﻿<div layout="row" layout-align="center center">
 
-    <md-content flex="66" class="md-whiteframe-z1">
-        <ent-search-box buttontext="Search" labeltext="id, title, url" query="vm.search.query" search="vm.searchPages()"></ent-search-box>
-        <md-toolbar class="md-theme-light">
-            <h2 class="md-toolbar-tools">
-                <span>Pages</span>
-            </h2>
-        </md-toolbar>
-        <md-content>
+    <md-content flex="66" flex-sm="100">
+        <ent-search-box buttontext="Search" labeltext="id, title, url" query="vm.search.query" search="vm.searchPages()"></ent-search-box>        
+        <md-content class="md-whiteframe-z1">
             <md-list>
                 <md-list-item ng-click="vm.selectItem(item)" class="md-3-line" data-ng-repeat="item in vm.search.results">
                     <div layout="row" layout-align="start center">
@@ -21,6 +16,9 @@
                     <md-divider ng-if="!$last"></md-divider>
                 </md-list-item>
             </md-list>
+        </md-content>
+        <md-content layout="row" layout-align="center center">
+            <pagination total-items="vm.paging.totalItems" data-ng-model="vm.paging.currentPage" data-ng-change="vm.paging.onSelectPage(page)" class="pagination-sm" previous-text="&lsaquo;" next-text="&rsaquo;" first-text="&laquo;" last-text="&raquo;" max-size="vm.paging.numPages"></pagination>
         </md-content>
     </md-content>
 </div>

--- a/Web/App/Video/Views/Index.html
+++ b/Web/App/Video/Views/Index.html
@@ -1,3 +1,3 @@
 ﻿<md-content layout="row" layout-align="center center">    
-    <video-search flex="75" selected-video="vm.selectedVideo"></video-search>
+    <video-search flex="75" selected-video="vm.selectedVideo" items-per-page="24"></video-search>
 </md-content>


### PR DESCRIPTION
Wrapped entSearch in a div instead of md-list
Added itemsPerPage attribute to control the number of videos listed in
videoSearch directive
Reduced the number of grid items from 6 to 4 on cols-gt-md
Removed md-toolbar in pages index.
